### PR TITLE
Audit Table Indexes

### DIFF
--- a/inform-annotations/src/main/java/uk/ac/ucl/rits/inform/informdb/annotation/AuditTable.java
+++ b/inform-annotations/src/main/java/uk/ac/ucl/rits/inform/informdb/annotation/AuditTable.java
@@ -5,8 +5,16 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import javax.persistence.Index;
+
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.SOURCE)
 public @interface AuditTable {
 
+    /**
+     * Optional indexes to pass to the generated @Table.
+     *
+     * @return Array of indexes to pass.
+     */
+    Index[] indexes() default {};
 }

--- a/inform-annotations/src/main/java/uk/ac/ucl/rits/inform/informdb/annotation/AuditTableProcessor.java
+++ b/inform-annotations/src/main/java/uk/ac/ucl/rits/inform/informdb/annotation/AuditTableProcessor.java
@@ -194,6 +194,7 @@ public class AuditTableProcessor extends AbstractProcessor {
         out.println("import javax.persistence.Id;");
         out.println("import javax.persistence.Inheritance;");
         out.println("import javax.persistence.InheritanceType;");
+        out.println("import javax.persistence.Index;");
         out.println("import javax.persistence.ManyToOne;");
         out.println("import javax.persistence.OneToOne;");
         out.println("import java.time.Instant;");


### PR DESCRIPTION
Audit table annotation now supports `@Tables` indexes argument to add indexes to generated audit tables.