### PR TITLE
Add indexes to lab sample question

### DIFF
--- a/inform-db/src/main/java/uk/ac/ucl/rits/inform/informdb/labs/LabSampleQuestion.java
+++ b/inform-db/src/main/java/uk/ac/ucl/rits/inform/informdb/labs/LabSampleQuestion.java
@@ -12,6 +12,7 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.Index;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
@@ -27,7 +28,8 @@ import java.time.Instant;
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 @AuditTable
-@Table()
+@Table(indexes = {@Index(name = "lsq_lab_sample_id", columnList = "labSampleId"),
+        @Index(name = "lsq_question_id", columnList = "questionId")})
 public class LabSampleQuestion extends TemporalCore<LabSampleQuestion, LabSampleQuestionAudit> {
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)


### PR DESCRIPTION
Queries only started being substantially slow once there was a large number of rows in the table. Running from beginning of epic time the query for an existing lab sample question took 50 ms!