### PR TITLE
Patient infection fixes

### DIFF
--- a/inform-db/src/main/java/uk/ac/ucl/rits/inform/informdb/conditions/ConditionType.java
+++ b/inform-db/src/main/java/uk/ac/ucl/rits/inform/informdb/conditions/ConditionType.java
@@ -37,9 +37,14 @@ public class ConditionType extends TemporalCore<ConditionType, ConditionTypeAudi
     private String dataType;
 
     /**
-     * disease or infection type.
+     * Code used within EPIC for condition.
      */
     @Column(nullable = false)
+    private String internalCode;
+
+    /**
+     * Human readable name for condition.
+     */
     private String name;
     private String standardisedCode;
     private String standardisedVocabulary;
@@ -47,12 +52,12 @@ public class ConditionType extends TemporalCore<ConditionType, ConditionTypeAudi
     /**
      * Minimal information constructor.
      * @param dataType   Type of patient state type; either patient infection or problem list
-     * @param name       Name of the patient state type
+     * @param code       EPIC code of the patient state type
      * @param validFrom  Timestamp from which information valid from
      * @param storedFrom Timestamp from which information stored from
      */
-    public ConditionType(String dataType, String name, Instant validFrom, Instant storedFrom) {
-        this.name = name;
+    public ConditionType(String dataType, String code, Instant validFrom, Instant storedFrom) {
+        this.internalCode = code;
         this.dataType = dataType;
         setValidFrom(validFrom);
         setStoredFrom(storedFrom);
@@ -65,6 +70,7 @@ public class ConditionType extends TemporalCore<ConditionType, ConditionTypeAudi
     public ConditionType(ConditionType other) {
         super(other);
         this.dataType = other.dataType;
+        this.internalCode = other.internalCode;
         this.name = other.name;
         this.standardisedCode = other.standardisedCode;
         this.standardisedVocabulary = other.standardisedVocabulary;

--- a/inform-db/src/main/java/uk/ac/ucl/rits/inform/informdb/conditions/ConditionType.java
+++ b/inform-db/src/main/java/uk/ac/ucl/rits/inform/informdb/conditions/ConditionType.java
@@ -1,4 +1,4 @@
-package uk.ac.ucl.rits.inform.informdb.state;
+package uk.ac.ucl.rits.inform.informdb.conditions;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -14,7 +14,7 @@ import javax.persistence.Id;
 import java.time.Instant;
 
 /**
- * Type of state that a patient can have.
+ * Type of condition that a patient can have.
  * Types are defined by the dataType (problem list or infection) and the name (problem list-> diagnosis; infection -> infection name)
  * @author Anika Cawthorn
  * @author Stef Piatek
@@ -24,11 +24,11 @@ import java.time.Instant;
 @EqualsAndHashCode(callSuper = true)
 @NoArgsConstructor
 @AuditTable
-public class PatientStateType extends TemporalCore<PatientStateType, PatientStateTypeAudit> {
+public class ConditionType extends TemporalCore<ConditionType, ConditionTypeAudit> {
 
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)
-    private long patientStateTypeId;
+    private long conditionTypeId;
 
     /**
      * problem list or patient infection.
@@ -46,12 +46,12 @@ public class PatientStateType extends TemporalCore<PatientStateType, PatientStat
 
     /**
      * Minimal information constructor.
-     * @param name       Name of the patient state type
      * @param dataType   Type of patient state type; either patient infection or problem list
+     * @param name       Name of the patient state type
      * @param validFrom  Timestamp from which information valid from
      * @param storedFrom Timestamp from which information stored from
      */
-    public PatientStateType(String name, String dataType, Instant validFrom, Instant storedFrom) {
+    public ConditionType(String dataType, String name, Instant validFrom, Instant storedFrom) {
         this.name = name;
         this.dataType = dataType;
         setValidFrom(validFrom);
@@ -62,7 +62,7 @@ public class PatientStateType extends TemporalCore<PatientStateType, PatientStat
      * Build a new PatientStateType from an existing one.
      * @param other existing PatientStateType
      */
-    public PatientStateType(PatientStateType other) {
+    public ConditionType(ConditionType other) {
         super(other);
         this.dataType = other.dataType;
         this.name = other.name;
@@ -72,13 +72,13 @@ public class PatientStateType extends TemporalCore<PatientStateType, PatientStat
     }
 
     @Override
-    public PatientStateType copy() {
-        return new PatientStateType(this);
+    public ConditionType copy() {
+        return new ConditionType(this);
     }
 
     @Override
-    public PatientStateTypeAudit createAuditEntity(Instant validUntil, Instant storedUntil) {
-        return new PatientStateTypeAudit(this, validUntil, storedUntil);
+    public ConditionTypeAudit createAuditEntity(Instant validUntil, Instant storedUntil) {
+        return new ConditionTypeAudit(this, validUntil, storedUntil);
     }
 
 }

--- a/inform-db/src/main/java/uk/ac/ucl/rits/inform/informdb/conditions/PatientCondition.java
+++ b/inform-db/src/main/java/uk/ac/ucl/rits/inform/informdb/conditions/PatientCondition.java
@@ -3,6 +3,7 @@ package uk.ac.ucl.rits.inform.informdb.conditions;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 import uk.ac.ucl.rits.inform.informdb.TemporalCore;
 import uk.ac.ucl.rits.inform.informdb.annotation.AuditTable;
 import uk.ac.ucl.rits.inform.informdb.identity.HospitalVisit;
@@ -27,6 +28,7 @@ import java.time.LocalDate;
 @Entity
 @Data
 @EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
 @NoArgsConstructor
 @AuditTable
 public class PatientCondition extends TemporalCore<PatientCondition, PatientConditionAudit> {
@@ -38,6 +40,8 @@ public class PatientCondition extends TemporalCore<PatientCondition, PatientCond
     @JoinColumn(name = "conditionTypeId", nullable = false)
     private ConditionType conditionTypeId;
 
+    private Long internalId;
+
     @ManyToOne
     @JoinColumn(name = "mrnId", nullable = false)
     private Mrn mrnId;
@@ -48,9 +52,6 @@ public class PatientCondition extends TemporalCore<PatientCondition, PatientCond
 
     @Column(nullable = false, columnDefinition = "timestamp with time zone")
     private Instant addedDateTime;
-
-    @Column(nullable = false)
-    private String sourceSystem;
 
     @Column(columnDefinition = "timestamp with time zone")
     private Instant resolutionDateTime;
@@ -75,10 +76,11 @@ public class PatientCondition extends TemporalCore<PatientCondition, PatientCond
      * @param mrn                patient ID
      * @param addedDateTime      when patient state has been added
      */
-    public PatientCondition(ConditionType conditionTypeId, Mrn mrn, Instant addedDateTime) {
+    public PatientCondition(Long internalId, ConditionType conditionTypeId, Mrn mrn, Instant addedDateTime) {
         this.conditionTypeId = conditionTypeId;
         this.mrnId = mrn;
         this.addedDateTime = addedDateTime;
+        this.internalId = internalId;
     }
 
     /**
@@ -92,8 +94,8 @@ public class PatientCondition extends TemporalCore<PatientCondition, PatientCond
         if (other.hospitalVisitId != null) {
             hospitalVisitId = other.hospitalVisitId;
         }
+        internalId = other.internalId;
         addedDateTime = other.addedDateTime;
-        sourceSystem = other.sourceSystem;
         resolutionDateTime = other.resolutionDateTime;
         onsetDate = other.onsetDate;
         classification = other.classification;

--- a/inform-db/src/main/java/uk/ac/ucl/rits/inform/informdb/conditions/PatientCondition.java
+++ b/inform-db/src/main/java/uk/ac/ucl/rits/inform/informdb/conditions/PatientCondition.java
@@ -72,9 +72,10 @@ public class PatientCondition extends TemporalCore<PatientCondition, PatientCond
 
     /**
      * Minimal information constructor.
+     * @param internalId      Id in epic for the patient condition
      * @param conditionTypeId ID for patient state type
-     * @param mrn                patient ID
-     * @param addedDateTime      when patient state has been added
+     * @param mrn             patient ID
+     * @param addedDateTime   when patient state has been added
      */
     public PatientCondition(Long internalId, ConditionType conditionTypeId, Mrn mrn, Instant addedDateTime) {
         this.conditionTypeId = conditionTypeId;

--- a/inform-db/src/main/java/uk/ac/ucl/rits/inform/informdb/conditions/PatientCondition.java
+++ b/inform-db/src/main/java/uk/ac/ucl/rits/inform/informdb/conditions/PatientCondition.java
@@ -1,4 +1,4 @@
-package uk.ac.ucl.rits.inform.informdb.state;
+package uk.ac.ucl.rits.inform.informdb.conditions;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -19,7 +19,7 @@ import java.time.Instant;
 import java.time.LocalDate;
 
 /**
- * Represents patient states that start and can end.
+ * Represents patient conditions that start and can end.
  * Currently envisaged as storing infection control's patient infection information and problem lists.
  * @author Anika Cawthorn
  * @author Stef Piatek
@@ -29,14 +29,14 @@ import java.time.LocalDate;
 @EqualsAndHashCode(callSuper = true)
 @NoArgsConstructor
 @AuditTable
-public class PatientState extends TemporalCore<PatientState, PatientStateAudit> {
+public class PatientCondition extends TemporalCore<PatientCondition, PatientConditionAudit> {
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)
-    private long patientStateId;
+    private long patientConditionId;
 
     @ManyToOne
-    @JoinColumn(name = "patientStateTypeId", nullable = false)
-    private PatientStateType patientStateTypeId;
+    @JoinColumn(name = "conditionTypeId", nullable = false)
+    private ConditionType conditionTypeId;
 
     @ManyToOne
     @JoinColumn(name = "mrnId", nullable = false)
@@ -68,12 +68,12 @@ public class PatientState extends TemporalCore<PatientState, PatientStateAudit> 
 
     /**
      * Minimal information constructor.
-     * @param patientStateTypeId ID for patient state type
+     * @param conditionTypeId ID for patient state type
      * @param mrn                patient ID
      * @param addedDateTime      when patient state has been added
      */
-    public PatientState(PatientStateType patientStateTypeId, Mrn mrn, Instant addedDateTime) {
-        this.patientStateTypeId = patientStateTypeId;
+    public PatientCondition(ConditionType conditionTypeId, Mrn mrn, Instant addedDateTime) {
+        this.conditionTypeId = conditionTypeId;
         this.mrnId = mrn;
         this.addedDateTime = addedDateTime;
     }
@@ -82,9 +82,9 @@ public class PatientState extends TemporalCore<PatientState, PatientStateAudit> 
      * Build a new PatientState from an existing one.
      * @param other existing PatientState
      */
-    public PatientState(PatientState other) {
+    public PatientCondition(PatientCondition other) {
         super(other);
-        this.patientStateTypeId = other.patientStateTypeId;
+        this.conditionTypeId = other.conditionTypeId;
         this.mrnId = other.mrnId;
         if (other.hospitalVisitId != null) {
             this.hospitalVisitId = other.hospitalVisitId;
@@ -99,13 +99,13 @@ public class PatientState extends TemporalCore<PatientState, PatientStateAudit> 
     }
 
     @Override
-    public PatientState copy() {
-        return new PatientState(this);
+    public PatientCondition copy() {
+        return new PatientCondition(this);
     }
 
     @Override
-    public PatientStateAudit createAuditEntity(Instant validUntil, Instant storedUntil) {
-        return new PatientStateAudit(this, validUntil, storedUntil);
+    public PatientConditionAudit createAuditEntity(Instant validUntil, Instant storedUntil) {
+        return new PatientConditionAudit(this, validUntil, storedUntil);
     }
 }
 

--- a/inform-db/src/main/java/uk/ac/ucl/rits/inform/informdb/conditions/PatientCondition.java
+++ b/inform-db/src/main/java/uk/ac/ucl/rits/inform/informdb/conditions/PatientCondition.java
@@ -50,7 +50,7 @@ public class PatientCondition extends TemporalCore<PatientCondition, PatientCond
     @JoinColumn(name = "hospitalVisitId")
     private HospitalVisit hospitalVisitId;
 
-    @Column(nullable = false, columnDefinition = "timestamp with time zone")
+    @Column(columnDefinition = "timestamp with time zone")
     private Instant addedDateTime;
 
     @Column(columnDefinition = "timestamp with time zone")

--- a/inform-db/src/main/java/uk/ac/ucl/rits/inform/informdb/conditions/PatientCondition.java
+++ b/inform-db/src/main/java/uk/ac/ucl/rits/inform/informdb/conditions/PatientCondition.java
@@ -49,6 +49,9 @@ public class PatientCondition extends TemporalCore<PatientCondition, PatientCond
     @Column(nullable = false, columnDefinition = "timestamp with time zone")
     private Instant addedDateTime;
 
+    @Column(nullable = false)
+    private String sourceSystem;
+
     @Column(columnDefinition = "timestamp with time zone")
     private Instant resolutionDateTime;
 
@@ -84,18 +87,19 @@ public class PatientCondition extends TemporalCore<PatientCondition, PatientCond
      */
     public PatientCondition(PatientCondition other) {
         super(other);
-        this.conditionTypeId = other.conditionTypeId;
-        this.mrnId = other.mrnId;
+        conditionTypeId = other.conditionTypeId;
+        mrnId = other.mrnId;
         if (other.hospitalVisitId != null) {
-            this.hospitalVisitId = other.hospitalVisitId;
+            hospitalVisitId = other.hospitalVisitId;
         }
-        this.addedDateTime = other.addedDateTime;
-        this.resolutionDateTime = other.resolutionDateTime;
-        this.onsetDate = other.onsetDate;
-        this.classification = other.classification;
-        this.status = other.status;
-        this.priority = other.priority;
-        this.comment = other.comment;
+        addedDateTime = other.addedDateTime;
+        sourceSystem = other.sourceSystem;
+        resolutionDateTime = other.resolutionDateTime;
+        onsetDate = other.onsetDate;
+        classification = other.classification;
+        status = other.status;
+        priority = other.priority;
+        comment = other.comment;
     }
 
     @Override

--- a/inform-db/src/main/java/uk/ac/ucl/rits/inform/informdb/conditions/package-info.java
+++ b/inform-db/src/main/java/uk/ac/ucl/rits/inform/informdb/conditions/package-info.java
@@ -1,4 +1,4 @@
 /**
  * States that can affect a patient (e.g. diagnoses and infections).
  */
-package uk.ac.ucl.rits.inform.informdb.state;
+package uk.ac.ucl.rits.inform.informdb.conditions;

--- a/inform-db/src/main/java/uk/ac/ucl/rits/inform/informdb/conditions/package-info.java
+++ b/inform-db/src/main/java/uk/ac/ucl/rits/inform/informdb/conditions/package-info.java
@@ -1,4 +1,4 @@
 /**
- * States that can affect a patient (e.g. diagnoses and infections).
+ * Conditions that can affect a patient (e.g. diagnoses and infections).
  */
 package uk.ac.ucl.rits.inform.informdb.conditions;

--- a/inform-db/src/main/java/uk/ac/ucl/rits/inform/informdb/state/PatientState.java
+++ b/inform-db/src/main/java/uk/ac/ucl/rits/inform/informdb/state/PatientState.java
@@ -39,7 +39,7 @@ public class PatientState extends TemporalCore<PatientState, PatientStateAudit> 
     private PatientStateType patientStateTypeId;
 
     @ManyToOne
-    @JoinColumn(name = "mnrId", nullable = false)
+    @JoinColumn(name = "mrnId", nullable = false)
     private Mrn mrnId;
 
     @ManyToOne


### PR DESCRIPTION
- renaming patient state -> patient condition because that seems more sensible (oopf that's a lot)
- fix typo in mrnId
- save the infection epic Id in the table so that rows from hoover can be easily queried by the infection type and the infection id (as added datetime not guaranteed to change)
- allow infections without an added date time to be parsed
