### PR TITLE
Add missing fields in copy constructors

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+## Reason for changes and summary
+<!--- 
+Add a summary of the reasons for this change (e.g. Fixes..., overview of reasons for each type of change) 
+Can be useful to document any assumptions or problems encountered
+-->
+
+## Checklist for submitter & reviewer
+
+- [ ] copy constructor copies the primary key Id of the entity
+- [ ] copy constructor copies all other fields of the entity, starting with `super(other)`
+- [ ] unique constraints added if appropriate
+- [ ] text definition added to columns which could have more than 255 characters
+- [ ] foreign key names are in the form `<entityClass>Id`, and no typos
+- [ ] during run, glowroot is checked for query speed and indexes added if needed
+- [ ] validation run completed and validated

--- a/inform-db/src/main/java/uk/ac/ucl/rits/inform/informdb/conditions/PatientCondition.java
+++ b/inform-db/src/main/java/uk/ac/ucl/rits/inform/informdb/conditions/PatientCondition.java
@@ -90,6 +90,7 @@ public class PatientCondition extends TemporalCore<PatientCondition, PatientCond
      */
     public PatientCondition(PatientCondition other) {
         super(other);
+        patientConditionId = other.patientConditionId;
         conditionTypeId = other.conditionTypeId;
         mrnId = other.mrnId;
         if (other.hospitalVisitId != null) {

--- a/inform-db/src/main/java/uk/ac/ucl/rits/inform/informdb/labs/LabSample.java
+++ b/inform-db/src/main/java/uk/ac/ucl/rits/inform/informdb/labs/LabSample.java
@@ -89,6 +89,8 @@ public class LabSample extends TemporalCore<LabSample, LabSampleAudit> {
         this.receiptAtLab = other.receiptAtLab;
         this.sampleCollectionTime = other.sampleCollectionTime;
         this.specimenType = other.specimenType;
+        this.sampleSite = other.sampleSite;
+        this.collectionMethod = other.collectionMethod;
     }
 
     @Override

--- a/inform-db/src/main/java/uk/ac/ucl/rits/inform/informdb/labs/LabSampleQuestion.java
+++ b/inform-db/src/main/java/uk/ac/ucl/rits/inform/informdb/labs/LabSampleQuestion.java
@@ -57,6 +57,7 @@ public class LabSampleQuestion extends TemporalCore<LabSampleQuestion, LabSample
 
     public LabSampleQuestion(LabSampleQuestion other) {
         super(other);
+        this.labSampleQuestionId = other.labSampleQuestionId;
         this.labSampleId = other.labSampleId;
         this.questionId = other.questionId;
         this.answer = other.answer;

--- a/inform-db/src/main/java/uk/ac/ucl/rits/inform/informdb/visit_recordings/VisitObservation.java
+++ b/inform-db/src/main/java/uk/ac/ucl/rits/inform/informdb/visit_recordings/VisitObservation.java
@@ -93,6 +93,7 @@ public class VisitObservation extends TemporalCore<VisitObservation, VisitObserv
      */
     public VisitObservation(VisitObservation other) {
         super(other);
+        this.visitObservationId = other.visitObservationId;
         this.visitObservationTypeId = other.visitObservationTypeId;
         this.hospitalVisitId = other.hospitalVisitId;
         this.valueAsText = other.valueAsText;


### PR DESCRIPTION
Is it worth also adding in a PR template for things to look for when reviewing informdb (off the top of my head from previous errors, anything else worthwhile?):

- [ ] copy constructor copies the primary key Id of the entity
- [ ] copy constuctor copies all other fields of the entity, starting with `super(other)`
- [ ] during run, glowroot is checked for query speed and indexes added if needed
- [ ] unique constraints added if appropriate
- [ ] text definition added to columns which could have more than 255 characters
- [ ] Foreign key names are in the form `<entityClass>Id`, and no typos
