### PR TITLE
Add index to visit observation type

### DIFF
--- a/inform-db/src/main/java/uk/ac/ucl/rits/inform/informdb/visit_recordings/VisitObservationType.java
+++ b/inform-db/src/main/java/uk/ac/ucl/rits/inform/informdb/visit_recordings/VisitObservationType.java
@@ -12,8 +12,10 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.Index;
 import javax.persistence.Inheritance;
 import javax.persistence.InheritanceType;
+import javax.persistence.Table;
 import java.time.Instant;
 
 /**
@@ -32,6 +34,7 @@ import java.time.Instant;
 @Inheritance(strategy = InheritanceType.TABLE_PER_CLASS)
 @NoArgsConstructor
 @AuditTable
+@Table(indexes = {@Index(name = "vot_id_in_application", columnList = "idInApplication")})
 public class VisitObservationType extends TemporalCore<VisitObservationType, VisitObservationTypeAudit> {
 
     @Id


### PR DESCRIPTION
## Reason for changes and summary
<!--- 
Add a summary of the reasons for this change (e.g. Fixes..., overview of reasons for each type of change) 
Can be useful to document any assumptions or problems encountered
-->

Now that we have a full load from caboodle, each query taking 11ms
without indexes. 0.4 ms with the index added